### PR TITLE
app-emulation/cri-o: More cleanups (doc USE flag, etc.)

### DIFF
--- a/app-emulation/cri-o/cri-o-1.9.9.ebuild
+++ b/app-emulation/cri-o/cri-o-1.9.9.ebuild
@@ -43,14 +43,14 @@ src_prepare() {
 
 src_compile() {
 	pushd src/${EGO_PN} || die
+	BUILDTAGS=""
+	if ! use btrfs; then BUILDTAGS="${BUILDTAGS} exclude_graphdriver_btrfs"; fi
+	if ! use device-mapper; then BUILDTAGS="${BUILDTAGS} exclude_graphdriver_devicemapper"; fi
+	if ! use ostree; then BUILDTAGS="${BUILDTAGS} containers_image_ostree_stub"; fi
+	if use seccomp; then BUILDTAGS="${BUILDTAGS} seccomp"; fi
+	if use selinux; then BUILDTAGS="${BUILDTAGS} selinux"; fi
 	GOPATH="${S}" GOBIN="${S}/bin" \
 		BASE_LDFLAGS=" -s -w -X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=Gentoo" \
-		BUILDTAGS=""
-		if ! use btrfs; then BUILDTAGS="${BUILDTAGS} exclude_graphdriver_btrfs"; fi
-		if ! use device-mapper; then BUILDTAGS="${BUILDTAGS} exclude_graphdriver_devicemapper"; fi
-		if ! use ostree; then BUILDTAGS="${BUILDTAGS} containers_image_ostree_stub"; fi
-		if use seccomp; then BUILDTAGS="${BUILDTAGS} seccomp"; fi
-		if use selinux; then BUILDTAGS="${BUILDTAGS} selinux"; fi
 		emake -j1 BUILDTAGS="${BUILDTAGS}"
 }
 

--- a/app-emulation/cri-o/cri-o-1.9.9.ebuild
+++ b/app-emulation/cri-o/cri-o-1.9.9.ebuild
@@ -49,6 +49,7 @@ src_compile() {
 	if ! use ostree; then BUILDTAGS="${BUILDTAGS} containers_image_ostree_stub"; fi
 	if use seccomp; then BUILDTAGS="${BUILDTAGS} seccomp"; fi
 	if use selinux; then BUILDTAGS="${BUILDTAGS} selinux"; fi
+	mkdir -p bin || die "failed to create bin"  # https://github.com/kubernetes-incubator/cri-o/pull/1459
 	GOPATH="${S}" GOBIN="${S}/bin" \
 		BASE_LDFLAGS=" -s -w -X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=Gentoo" \
 		emake BUILDTAGS="${BUILDTAGS}" binaries

--- a/app-emulation/cri-o/cri-o-1.9.9.ebuild
+++ b/app-emulation/cri-o/cri-o-1.9.9.ebuild
@@ -51,7 +51,7 @@ src_compile() {
 	if use selinux; then BUILDTAGS="${BUILDTAGS} selinux"; fi
 	GOPATH="${S}" GOBIN="${S}/bin" \
 		BASE_LDFLAGS=" -s -w -X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=Gentoo" \
-		emake -j1 BUILDTAGS="${BUILDTAGS}"
+		emake BUILDTAGS="${BUILDTAGS}"
 }
 
 src_install() {

--- a/app-emulation/cri-o/cri-o-1.9.9.ebuild
+++ b/app-emulation/cri-o/cri-o-1.9.9.ebuild
@@ -19,7 +19,7 @@ SRC_URI="${ARCHIVE_URI}"
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE="btrfs device-mapper ostree seccomp selinux"
+IUSE="btrfs device-mapper doc ostree seccomp selinux"
 
 RDEPEND="
 	net-misc/cni-plugins
@@ -31,7 +31,7 @@ RDEPEND="
 	selinux? ( sys-libs/libselinux )"
 DEPEND="
 	${RDEPEND}
-	dev-go/go-md2man"
+	doc? ( dev-go/go-md2man )"
 
 src_prepare() {
 	default
@@ -51,13 +51,15 @@ src_compile() {
 	if use selinux; then BUILDTAGS="${BUILDTAGS} selinux"; fi
 	GOPATH="${S}" GOBIN="${S}/bin" \
 		BASE_LDFLAGS=" -s -w -X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=Gentoo" \
-		emake BUILDTAGS="${BUILDTAGS}"
+		emake BUILDTAGS="${BUILDTAGS}" binaries
+	if use doc; then emake docs; fi
 }
 
 src_install() {
 	pushd src/${EGO_PN} || die
 
-	emake DESTDIR="${D}" PREFIX="${D}${EPREFIX}/usr" install
+	emake DESTDIR="${D}" PREFIX="${D}${EPREFIX}/usr" install.bin
+	if use doc; then emake DESTDIR="${D}" PREFIX="${D}${EPREFIX}/usr" install.man; fi
 
 	dodir   /etc/crio
 	insinto /etc/crio


### PR DESCRIPTION
I've grouped a few mostly-orthogonal fixups in this PR.  I'm happy to split them up if that would make review easier.  Details are in the commit messages, but a summary is:

* Create the `bin` directory, to work around an upstream issue (kubernetes-incubator/cri-o#1459).
* Add `doc` to `IUSE`, so folks who don't need the man pages can avoid the `go-md2man` dependency.
* Drop `-j1`, to avoid [repoman complaining][1] about parallel compilation.
* Fix `BUILDTAGS` generation.  I'd missed the line-continuation `\` in c2cf09d (#8).

[1]: https://travis-ci.org/D3fy/defiance-overlay/builds/354373864#L499